### PR TITLE
Add intellij plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,22 @@
+buildscript {
+
+    repositories {
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    }
+
+    dependencies {
+        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.0-SNAPSHOT"
+    }
+}
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.0-rc-57'
+}
+
+apply plugin: 'org.jetbrains.intellij'
+
+intellij {
+    version = "2018.2.3"
 }
 
 group 'org.jetbrains.qa'
@@ -14,7 +31,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation 'com.example:lib2-jvm:1.0'
+    compile 'com.example:lib2-jvm:1.0'
 }
 
 compileKotlin {


### PR DESCRIPTION
Running the prepareSandbox gradle task results in:

```
22:27:47: Executing task 'prepareSandbox'...


FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':prepareSandbox'.
> Could not resolve all files for configuration ':runtime'.
   > Could not resolve com.example:lib1:1.0.
     Required by:
         project : > com.example:lib2-jvm:1.0
      > Cannot choose between the following configurations of com.example:lib1:1.0:
          - js-runtime
          - jvm-runtime
        All of them match the consumer attributes:
          - Configuration 'js-runtime':
              - Found artifactType 'jar' but wasn't required.
              - Found org.gradle.status 'release' but wasn't required.
              - Found org.gradle.usage 'java-runtime-jars' but wasn't required.
              - Found org.jetbrains.kotlin.platform.type 'js' but wasn't required.
          - Configuration 'jvm-runtime':
              - Found artifactType 'jar' but wasn't required.
              - Found org.gradle.status 'release' but wasn't required.
              - Found org.gradle.usage 'java-runtime-jars' but wasn't required.
              - Found org.jetbrains.kotlin.platform.type 'jvm' but wasn't required.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
Cannot choose between the following configurations of com.example:lib1:1.0:
  - js-runtime
  - jvm-runtime
All of them match the consumer attributes:
  - Configuration 'js-runtime':
      - Found artifactType 'jar' but wasn't required.
      - Found org.gradle.status 'release' but wasn't required.
      - Found org.gradle.usage 'java-runtime-jars' but wasn't required.
      - Found org.jetbrains.kotlin.platform.type 'js' but wasn't required.
  - Configuration 'jvm-runtime':
      - Found artifactType 'jar' but wasn't required.
      - Found org.gradle.status 'release' but wasn't required.
      - Found org.gradle.usage 'java-runtime-jars' but wasn't required.
      - Found org.jetbrains.kotlin.platform.type 'jvm' but wasn't required.
22:27:48: Task execution finished 'prepareSandbox'.
```